### PR TITLE
Entity: Remove the empty constructor

### DIFF
--- a/include/entity.hpp
+++ b/include/entity.hpp
@@ -11,9 +11,9 @@ class Game;
 class Entity
 {
 protected:
-  PlayState *playState;
+  PlayState *const playState;
+
 public:
-  Entity();
   Entity(PlayState *playState);
   virtual ~Entity(void);
   virtual void update(void) = 0;

--- a/source/entity.cpp
+++ b/source/entity.cpp
@@ -1,9 +1,5 @@
 #include "entity.hpp"
 
-Entity::Entity()
-{
-}
-
 Entity::Entity(PlayState *playState) : playState(playState)
 {
 }


### PR DESCRIPTION
The `playState` member was not initialized by this empty constructor, which is likely an error.

This constructor is unused.
