### PR TITLE
Better Camera class

### DIFF
--- a/include/camera.hpp
+++ b/include/camera.hpp
@@ -12,14 +12,22 @@ public:
   Camera(void);
   ~Camera(void);
 
-  void	setCamera(double x, double y);
-  void	moveCamera(double x, double y);
-  void	changeAngle(int x, int y);
-  Vect<2u, double> const &getCamera(void) const;
-  Vect<2u, int> const &getAngle(void) const;
-  Vect<2u, int> const getFlooredCamera(void) const;
+  Vect<2u, double> getPosition(void) const;
+  void	setPosition(const Vect<2u, double> &position);
+
+  /**
+   * The given offset is relative to the actual camera position
+   */
+  void	move(const Vect<2u, double> &offset);
+
+
+  Vect<2u, int> getAngle(void) const;
+  void setAngle(const Vect<2u, int> &angle);
+
+  Vect<2u, int> getFlooredCamera(void) const;
+
 private:
-  Vect<2, double> lookat;
+  Vect<2, double> position;
   Vect<2, int> angle;
 };
 

--- a/include/display.hpp
+++ b/include/display.hpp
@@ -46,11 +46,14 @@ public:
   void addRenderable(Renderable *renderable);
   void removeRenderable(Renderable *renderable);
 
-  void moveCamera(double x, double y);
-  void setCamera(double x, double y);
-  void changeAngle(int x, int y);
-  Vect <2, double> const &getCamera() const;
-  Vect <2, double> const getIngameCursor() const;
+  Vect <2, double> getCameraPosition() const;
+  void setCameraPosition(Vect<2, double> newPosition);
+  void moveCamera(Vect<2, double> offset);
+
+  Vect <2, int> getCameraAngle() const;
+  void setCameraAngle(Vect <2, int> angle);
+
+  Vect <2, double> getIngameCursor() const;
 
   void transformation(Tile const &, int line_x, int line_y);
   void calcAngle(Vect<2, int> & pos, Vect<2, int> const & win_pos);

--- a/include/vect.hpp
+++ b/include/vect.hpp
@@ -258,7 +258,7 @@ public:
   }
 
   template<unsigned int _dim = dim, typename std::enable_if<(dim > 0)>::type* = nullptr>
-  T x()
+  T x() const
   {
     return (data[0]);
   }

--- a/source/camera.cpp
+++ b/source/camera.cpp
@@ -5,7 +5,7 @@
 
 Camera::Camera(void)
 {
-  lookat = Vect<2, double>(TILE_DIM / 2, TILE_DIM / 2);
+  position = Vect<2, double>(TILE_DIM / 2, TILE_DIM / 2);
   angle = Vect<2, int>(0, 0);
 }
 
@@ -13,35 +13,38 @@ Camera::~Camera(void)
 {
 }
 
-Vect<2u, int> const Camera::getFlooredCamera(void) const
+
+Vect<2u, double> Camera::getPosition(void) const
 {
-  return (Vect<2u, int>(lookat) + Vect<2u, int>(lookat[0] < 0 && (int)lookat[0] != lookat[0],
-						lookat[1] < 0 && (int)lookat[1] != lookat[1]));
+  return (position);
 }
 
-Vect<2u, double> const &Camera::getCamera(void) const
+void Camera::setPosition(const Vect<2u, double> &newPosition)
 {
-  return (lookat);
+  position = newPosition;
 }
 
-Vect<2u, int> const &Camera::getAngle(void) const
+void Camera::move(const Vect<2, double> &offset)
+{
+  position += offset;
+}
+
+
+Vect<2u, int> Camera::getAngle(void) const
 {
   return (angle);
 }
 
-void Camera::changeAngle(int x, int y)
+void Camera::setAngle(const Vect<2u, int> &newAngle)
 {
-  angle ^= Vect<2, int>(x, y);
+  angle ^= newAngle;
 }
 
-void Camera::setCamera(double x, double y)
-{
-  lookat[0] = x;
-  lookat[1] = y;
-}
 
-void Camera::moveCamera(double x, double y)
+Vect<2u, int> Camera::getFlooredCamera(void) const
 {
-  lookat[0] += x;
-  lookat[1] += y;
+  Vect<2, int> offset(position.x() < 0 && (int)position.x() != position.x(),
+                      position.y() < 0 && (int)position.y() != position.y());
+
+  return Vect<2u, int>(position) + offset;
 }

--- a/source/display.cpp
+++ b/source/display.cpp
@@ -51,7 +51,7 @@ void Display::displayRenderable(Renderable *renderable)
   rect.h = static_cast<int>((*renderable->dimensions)[1] * 120.0);
   x = (int)round((*renderable->position)[0]);
   y = (int)round((*renderable->position)[1]);
-  tmp = (*renderable->position - getCamera());
+  tmp = *renderable->position - getCameraPosition();
   tmp = display::fullIsometrize(tmp);
   rect.x = static_cast<int>(tmp[0]) + ((game->getWindowWidth() - rect.w) / 2);
   rect.y = static_cast<int>(tmp[1]) + game->getWindowHeight() / 2 - rect.h;
@@ -73,27 +73,35 @@ void Display::removeRenderable(Renderable *renderable)
   renderables.erase(renderables.begin() + i);
 }
 
-void Display::moveCamera(double x, double y)
+
+Vect <2, double> Display::getCameraPosition() const
 {
-  camera.moveCamera(x, y);
+  return (camera.getPosition());
 }
 
-void Display::setCamera(double x, double y)
+void Display::moveCamera(Vect<2, double> offset)
 {
-  camera.setCamera(x, y);
+  camera.move(offset);
 }
 
-Vect <2, double> const &Display::getCamera() const
+void Display::setCameraPosition(Vect<2, double> newPosition)
 {
-  return (camera.getCamera());
+  camera.setPosition(newPosition);
 }
 
-void Display::changeAngle(int x, int y)
+
+Vect <2, int> Display::getCameraAngle() const
 {
-  camera.changeAngle(x, y);
+  return camera.getAngle();
+};
+
+void Display::setCameraAngle(Vect<2, int> angle)
+{
+  camera.setAngle(angle);
 }
 
-Vect<2u, double> const Display::getIngameCursor() const
+
+Vect<2u, double> Display::getIngameCursor() const
 {
   Vect<2, double>	true_cursor;
   int			x;
@@ -104,7 +112,7 @@ Vect<2u, double> const Display::getIngameCursor() const
   true_cursor[0] = x - game->getWindowWidth() / 2;
   true_cursor[1] = y - game->getWindowHeight() / 2;
   true_cursor = true_cursor * Vect<2u, double>(1.0 / 120.0, 1.0 / 60.0);
-  true_cursor = true_cursor + Vect<2u, double>(true_cursor[1], -true_cursor[0]) + getCamera();
+  true_cursor = true_cursor + Vect<2u, double>(true_cursor[1], -true_cursor[0]) + getCameraPosition();
   h = maxRenderHeight;
   while (h > 0)
     {
@@ -140,13 +148,13 @@ void Display::centerBoard(SDL_Rect& win) const
 
 void Display::calcAngle(Vect<2, int> & pos, Vect<2, int> const & win_pos)
 {
-  Vect<2u, int> angle = camera.getAngle();
+  Vect<2u, int> angle = getCameraAngle();
 
   if (!!(win_pos[1] & (1 << 0)))
-    pos[0] += (((TILE_DIM / 2 - win_pos[0]) * 2 - 1) * 120 * angle[0]);
+    pos[0] += ((TILE_DIM / 2 - win_pos[0]) * 2 - 1) * 120 * angle[0];
   else
-    pos[0] += (((TILE_DIM / 2 - win_pos[0]) * 2) * 120 * angle[0]);
-  pos[1] += ((((TILE_DIM * 2 - 2) / 2 - win_pos[1]) * 2) * 30 * angle[1]);
+    pos[0] += ((TILE_DIM / 2 - win_pos[0]) * 2) * 120 * angle[0];
+  pos[1] += (((TILE_DIM * 2 - 2) / 2 - win_pos[1]) * 2) * 30 * angle[1];
 }
 
 void Display::transformation(Tile const &tile, int line_x, int line_y)
@@ -154,7 +162,7 @@ void Display::transformation(Tile const &tile, int line_x, int line_y)
   SDL_Rect win;
   Vect<2u, int> tmp(tile.pos);
 
-  tmp = display::fullIsometrize(tmp) - Vect<2u, int>(display::fullIsometrize(camera.getCamera()));
+  tmp = display::fullIsometrize(tmp) - Vect<2u, int>(display::fullIsometrize(getCameraPosition()));
   calcAngle(tmp, Vect<2, int>(line_x, line_y));
   win.x = tmp[0];
   win.y = tmp[1]- tile.height * 15;
@@ -177,7 +185,6 @@ void Display::displayLine(Terrain &terrain, SDL_Rect const &rect, int x, int y, 
       --y;
       --line;
     }
-  cout << endl;
 }
 
 void Display::displayLines(Terrain &terrain, SDL_Rect const &rect)
@@ -213,7 +220,7 @@ void Display::displayReversedLines(Terrain &terrain, SDL_Rect const &rect)
 
 void Display::displayTiles(Terrain &terrain)
 {
-  Vect<2u, int> angle = camera.getAngle();
+  Vect<2u, int> angle = getCameraAngle();
   Vect<2u, int> cam;
   SDL_Rect rect;
 

--- a/source/playstate.cpp
+++ b/source/playstate.cpp
@@ -50,36 +50,34 @@ void PlayState::handleEvent(void)
           game->quit();
           return;
         case SDLK_SPACE:
-	  {
-	    Vect<2, double> pos = perso->getPosition();
-	    display.setCamera(pos[0], pos[1]);
-	  }
+          display.setCameraPosition(perso->getPosition());
 	  break;
 	case SDLK_F3:
 	  game->toggleShowFps();
 	  break;
         case SDLK_UP:
-          display.moveCamera(0, -0.2);
+          display.moveCamera(Vect<2, double>(0, -0.2));
           break;
         case SDLK_DOWN:
-          display.moveCamera(0, 0.2);
+          display.moveCamera(Vect<2, double>(0, 0.2));
           break;
         case SDLK_LEFT:
-          display.moveCamera(-0.2, 0);
+          display.moveCamera(Vect<2, double>(-0.2, 0));
           break;
         case SDLK_RIGHT:
-          display.moveCamera(0.2, 0);
+          display.moveCamera(Vect<2, double>(0.2, 0));
           break;
         case SDLK_a:
 	  std::cout << "yolo" << std::endl;
-          display.changeAngle(1, 0);
+          display.setCameraAngle(Vect<2, int>(1, 0));
           break;
         case SDLK_q:
-          display.changeAngle(0, 1);
+          display.setCameraAngle(Vect<2, int>(0, 1));
           break;
 	case SDLK_p:
 	  {
-	    Vect<2, double> tmp = display.getCamera();
+	    Vect<2, double> tmp = display.getCameraPosition();
+            // TODO: Use `cout`
 	    printf("cam pos: x %f, y %f\n", tmp[0], tmp[1]);
 	  }
 	  break;


### PR DESCRIPTION
I have renamed `Camera::lookat` to `Camera::position`. I think it's more appropriated since we have only two dimensions.

I have renamed `Camera::moveCamera()` and `Camera::setCamera()` to `Camera::move()` and `Camera::setPosition()` respectively. The `Camera` in the function names is useless.

I have renamed a few functions based on these one to keep the overall consistency.
